### PR TITLE
Add IITC mobile CE Version to proxy list

### DIFF
--- a/proxy.txt
+++ b/proxy.txt
@@ -34,6 +34,7 @@ com.chrome.canary
 com.chrome.dev
 com.cl.newt66y
 com.cradle.iitc_mobile
+org.exarhteam.iitc_mobile
 com.cygames.shadowverse
 com.devhd.feedly
 com.devolver.reigns2


### PR DESCRIPTION
It is an optional version of IITC mobile, an ingress game map.
新增IITC-CE版包名（ingress游戏的一个地图辅助应用 play可以查到），方便ingress玩家一键分应用代理